### PR TITLE
Force release-branch-semver version scheme of setuptools_scm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ defaults:
 
 env:
   PACKAGE_NAME: labscript-suite
-  SCM_VERSION_SCHEME: release-branch-semver
-  SCM_LOCAL_SCHEME: no-local-version
   ANACONDA_USER: labscript-suite
 
   # Configuration for a package with compiled extensions:

--- a/labscript_suite/__version__.py
+++ b/labscript_suite/__version__.py
@@ -1,19 +1,16 @@
-import os
 from pathlib import Path
+
 try:
     import importlib.metadata as importlib_metadata
 except ImportError:
     import importlib_metadata
 
-VERSION_SCHEME = {
-    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
-    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
-}
 
 root = Path(__file__).parent.parent
 if (root / '.git').is_dir():
     from setuptools_scm import get_version
-    __version__ = get_version(root, **VERSION_SCHEME)
+
+    __version__ = get_version(root, version_scheme="release-branch-semver")
 else:
     try:
         __version__ = importlib_metadata.version(__package__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm"]
+requires = ["setuptools", "wheel", "setuptools_scm>=4.1.0"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm>=4.1.0"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=4.1.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+version_scheme = "release-branch-semver"
+local_scheme = "node-and-date"

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
   importlib_metadata
-  setuptools_scm
+  setuptools_scm>=4.1.0
   blacs>=3.0.0
   labscript>=3.0.0
   labscript-devices>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import os
 from setuptools import setup
 
-setup(use_scm_version={"version_scheme": "release-branch-semver"})
+setup()

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,4 @@
 import os
 from setuptools import setup
 
-VERSION_SCHEME = {
-    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
-    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
-}
-
-setup(use_scm_version=VERSION_SCHEME)
+setup(use_scm_version={"version_scheme": "release-branch-semver"})


### PR DESCRIPTION
The release-branch-semver version scheme was added in setuptools_scm v4.1.0. We currently don't require this version of setuptools_scm, and the release-branch-semver scheme is only used if the environment variable `SCM_VERSION_SCHEME` is set to this value (e.g. during our CI build).

This PR:
* Requires `setuptools_scm>=4.1.0` and always uses release-branch-semver. This will ensure consistency between local editable installations and distributed versions (including those on Test PyPI).
* Makes all setuptools_scm configuration declarative, using the [tools.setuptools_scm] section of pyproject.toml. This is per the preferred configuration of setuptools_scm, and no other declarative config is supported (e.g. setup.cfg) that allows the arguments of `setuptools_scm.get_version()` to be specified (e.g. `version_scheme`). Doing so requires using [toml] extras of setuptools_scm and setuptools>=42.
* Omits the environment variables `SCM_VERSION_SCHEME` and `SCM_LOCAL_SCHEME` from the GitHub Actions workflow.