### PR TITLE
Fix docs builds

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,4 +45,5 @@ docs =
   sphinx-rtd-theme==0.5.2
   recommonmark==0.6.0
   m2r==0.2.1
+  mistune<=2.0.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,5 +46,5 @@ docs =
   sphinx-rtd-theme==0.5.2
   recommonmark==0.6.0
   m2r==0.2.1
-  mistune<=2.0.0
+  mistune<2.0.0
 


### PR DESCRIPTION
This should fix the current breakage in doc builds due to a dependency of m2r being updated in a backwards incompatible way and m2r no longer being supported to accommodate the changes.