### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,13 +198,6 @@ jobs:
           name: conda_packages
           path: ./conda_packages
 
-      - name: Publish on TestPyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.testpypi }}
-          repository_url: https://test.pypi.org/legacy/
-
       - name: Get Version Number
         if: github.event.ref_type == 'tag'
         run: |
@@ -233,6 +226,13 @@ jobs:
           asset_path: ./dist/${{ env.PACKAGE_NAME }}-${{ env.VERSION }}.tar.gz
           asset_name: ${{ env.PACKAGE_NAME }}-${{ env.VERSION }}.tar.gz
           asset_content_type: application/gzip
+
+      - name: Publish on TestPyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.testpypi }}
+          repository_url: https://test.pypi.org/legacy/
 
       - name: Publish on PyPI
         if: github.event.ref_type == 'tag'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,8 +124,7 @@ jobs:
           conda update -n base -c defaults conda
           conda create -n py${{ matrix.python }} python=${{ matrix.python }}
           conda activate py${{ matrix.python }}
-          conda install -c cbillington setuptools-conda
-          pip install --upgrade setuptools_scm
+          conda install -c labscript-suite setuptools-conda
           setuptools-conda build $CONDA_BUILD_ARGS .
 
       - name: Conda Package (Windows)
@@ -138,8 +137,7 @@ jobs:
           conda update -n base -c defaults conda && ^
           conda create -n py${{ matrix.python }} python=${{ matrix.python }} && ^
           conda activate py${{ matrix.python }} && ^
-          conda install -c cbillington setuptools-conda && ^
-          pip install --upgrade setuptools_scm && ^
+          conda install -c labscript-suite setuptools-conda && ^
           setuptools-conda build %CONDA_BUILD_ARGS% .
 
       - name: Upload Artifact

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,15 +73,15 @@ master_doc = 'index'
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'qtutils': ('https://qtutils.readthedocs.io/en/stable/', None),
     'pyqtgraph': (
         'https://pyqtgraph.readthedocs.io/en/latest/',
         None,
     ),  # change to stable once v0.11 is published
-    'matplotlib': ('https://matplotlib.org/', None),
-    'h5py': ('http://docs.h5py.org/en/stable/', None),
+    'matplotlib': ('https://matplotlib.org/stable/', None),
+    'h5py': ('https://docs.h5py.org/en/stable/', None),
     'pydaqmx': ('https://pythonhosted.org/PyDAQmx/', None),
     'qt': (
         '',

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,4 +47,5 @@ docs =
   recommonmark==0.6.0
   m2r==0.2.1
   mistune<2.0.0
+  jinja<3.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,10 +42,9 @@ spincore = spinapi
 nidaqmx = PyDAQmx
 nivision = PyNIVision
 docs = 
-  Sphinx==3.5.4
+  Sphinx==4.4.0
   sphinx-rtd-theme==0.5.2
   recommonmark==0.6.0
   m2r==0.2.1
   mistune<2.0.0
-  jinja2<3.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,5 +47,5 @@ docs =
   recommonmark==0.6.0
   m2r==0.2.1
   mistune<2.0.0
-  jinja<3.1
+  jinja2<3.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ spincore = spinapi
 nidaqmx = PyDAQmx
 nivision = PyNIVision
 docs = 
-  Sphinx==3.5.3
+  Sphinx==3.5.4
   sphinx-rtd-theme==0.5.2
   recommonmark==0.6.0
   m2r==0.2.1


### PR DESCRIPTION
Fixes #69 by changing channel `setuptools-conda` is pulled from.

Also remove no longer necessary separate install of updated `setuptools-scm` from pip and changes the order of operations for releasing (such that github releasing is done before uploading to TestPyPI).