### PR TITLE
Remove explicit references to `py38` in the conda install directions.

### DIFF
--- a/docs/source/installation/developer-anaconda.rst
+++ b/docs/source/installation/developer-anaconda.rst
@@ -8,7 +8,7 @@ Developer installations are useful for those who want to customise the *labscrip
     Moreover, there is now an option to write and use custom labscript device drivers outside of the labscript-devices installation directory.
 
 
-In this example, we will use an existing conda environment named `py38`.
+In this example, we will use an existing conda environment named `labscript`.
 Skip the first line/step if continuing on from the instructions to :ref:`set up this environment <installation/setting-up-an-environment:Anaconda Python>`.
 
 .. attention:: 
@@ -21,8 +21,8 @@ Skip the first line/step if continuing on from the instructions to :ref:`set up 
 Quick start
 -----------
 
-.. note:: After the first line, the current directory is ommited from the command prompt
-    for brevity.
+.. note:: 
+    After the first line, the current directory is ommited from the command prompt for brevity.
 
 .. code-block:: console
 
@@ -35,16 +35,17 @@ Quick start
     (base) > git clone https://github.com/wkheisenberg/runviewer
     (base) > git clone https://github.com/wkheisenberg/labscript-devices
     (base) > git clone https://github.com/wkheisenberg/labscript-utils
-    (base) > conda activate py38
-    (py38) > conda config --env --append channels labscript-suite
-    (py38) > conda install setuptools-conda pyqt pip desktop-app
-    (py38) > setuptools-conda install-requirements ^ 
+    (base) > conda activate labscript
+    (labscript) > conda config --env --append channels labscript-suite
+    (labscript) > conda install setuptools-conda pyqt pip desktop-app
+    (labscript) > setuptools-conda install-requirements ^ 
              labscript runmanager blacs lyse runviewer labscript-devices labscript-utils
-    (py38) > pip install --no-build-isolation --no-deps ^
+    (labscript) > pip install --no-build-isolation --no-deps ^
              -e labscript -e runmanager -e blacs -e lyse ^
              -e runviewer -e labscript-devices -e labscript-utils
-    (py38) > labscript-profile-create
-    (py38) > desktop-app install blacs lyse runmanager runviewer
+    (labscript) > labscript-profile-create
+    (labscript) > desktop-app install blacs lyse runmanager runviewer
+    (labscript) > conda remove conda # optional but highly recommended
 
 Detailed instructions
 ---------------------
@@ -96,7 +97,7 @@ The following is a detailed explanation of the steps provided in the Quick start
 
 #. Continue from step 4 (create the labscript profile) in the :doc:`regular-anaconda` instructions.
 
-#. (Optional, but Recommended) Remove `conda` and its dependencies from the `py38` environment.
+#. (Optional, but Recommended) Remove `conda` and its dependencies from the `labscript` environment.
    This will allow you to use the standard Anaconda Prompt again with this environment without issues.
    The particular issue being addressed is that `setuptools-conda` installs the `conda` package in a non-base environment, which can cause issues.
    Once the installation is complete, `setuptools-conda` and its dependices are no longer needed and can be safely removed using:

--- a/docs/source/installation/regular-anaconda.rst
+++ b/docs/source/installation/regular-anaconda.rst
@@ -1,7 +1,7 @@
 Regular installation (Anaconda Cloud)
 =====================================
 
-In this example, we will use an existing conda environment named `py38`.
+In this example, we will use an existing conda environment named `labscript`.
 Skip the first line/step if continuing on from the instructions to :ref:`set up this environment <installation/setting-up-an-environment:Anaconda Python>`.
 
 
@@ -10,11 +10,11 @@ Quick start
 
 .. code-block:: console
 
-    (base) C:\> conda activate py38
+    (base) C:\> conda activate labscript
     (base) C:\> conda config --env --append channels labscript-suite
-    (py38) C:\> conda install labscript-suite pyqt
-    (py38) C:\> labscript-profile-create
-    (py38) C:\> desktop-app install blacs lyse runmanager runviewer
+    (labscript) C:\> conda install labscript-suite pyqt
+    (labscript) C:\> labscript-profile-create
+    (labscript) C:\> desktop-app install blacs lyse runmanager runviewer
 
 
 Detailed instructions
@@ -24,34 +24,34 @@ Detailed instructions
 
   .. code-block:: console
 
-    (base) C:\> conda activate py38
+    (base) C:\> conda activate labscript
 
 2. Add the `labscript-suite` channel on `Anaconda Cloud <https://anaconda.org/labscript-suite>`_ to the current conda environment:
 
   .. code-block:: console
 
-    (py38) C:\> conda config --env --add channels labscript-suite
+    (labscript) C:\> conda config --env --add channels labscript-suite
 
 3. Install the meta-package (`labscript-suite`) and bindings to the GUI toolkit (`pyqt`) from Anaconda Cloud.
    This will install blacs, labscript, labscript-devices, labscript-utils, lyse, runmanager, runviewer, and all dependencies:
 
   .. code-block:: console
 
-    (py38) C:\> conda install labscript-suite pyqt
+    (labscript) C:\> conda install labscript-suite pyqt
 
 
 4. Create a profile directory in your home directory (the location of user data; see :doc:`/changes`):
 
   .. code-block:: console
 
-    (py38) C:\> labscript-profile-create
+    (labscript) C:\> labscript-profile-create
 
 
 5. (Optional) Create shortcuts for the GUI applications (blacs, lyse, runmanager, and runviewer) and place them in the start-menu (or non-Windows OS equivalent).
 
    .. code-block:: console
 
-       (py38) C:\> desktop-app install blacs lyse runmanager runviewer
+       (labscript) C:\> desktop-app install blacs lyse runmanager runviewer
 
 
    These will be named, e.g. 'runmanager – the labcript suite (py38)' which when clicked on will:
@@ -67,7 +67,7 @@ Alternatively, you can launch the applications from the Anaconda Prompt in the ,
 
 .. code-block:: console
 
-    (py38) C:\> runmanager
+    (labscript) C:\> runmanager
 
 
 This will print debugging information to the console.
@@ -92,28 +92,28 @@ Individual components of the labscript suite can be updated using the |conda-upd
 
 .. code-block:: console
 
-    (py38) C:\> conda update -c labscript-suite runmanager
+    (labscript) C:\> conda update -c labscript-suite runmanager
 
 
 To upgrade to a pre-release version, you can use the test label:
 
 .. code-block:: console
 
-    (py38) C:\> conda upadte -c labscript-suite/label/test runmanager
+    (labscript) C:\> conda upadte -c labscript-suite/label/test runmanager
 
 
 If updating multiple components, use a single |conda-update|_ command to assist dependency resolution:
 
 .. code-block:: console
 
-    (py38) C:\> conda update -c labscript-suite labscript lyse runmanager
+    (labscript) C:\> conda update -c labscript-suite labscript lyse runmanager
 
 
 You can also update (or downgrade) to a specific version:
 
 .. code-block:: console
 
-    (py38) C:\> conda update runmanager==2.5.0
+    (labscript) C:\> conda update runmanager==2.5.0
 
 
 .. |conda-update| replace:: ``conda update``

--- a/docs/source/installation/setting-up-an-environment.rst
+++ b/docs/source/installation/setting-up-an-environment.rst
@@ -36,7 +36,7 @@ though some device drivers may require an older version of python to operate cor
 
 .. code-block:: console
 
-    (base) C:\> conda create -n labscript python=3.12
+    (base) C:\> conda create -n labscript python=3.11
     (base) C:\> conda activate labscript
     (labscript) C:\>
 

--- a/docs/source/installation/setting-up-an-environment.rst
+++ b/docs/source/installation/setting-up-an-environment.rst
@@ -9,7 +9,8 @@ Below we outline how to create and activate a virtual environment for Anaconda P
 Anaconda Python
 ---------------
 Anaconda Python includes a `virtual environment manager <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_ as part of the `conda` executable.
-Here's an example (on Windows):
+Below is an example (on Windows).
+
 
 .. note::
 
@@ -27,13 +28,19 @@ Here's an example (on Windows):
 Quickstart
 **********
 
+When creating a new virtual enviornment, it is preferrable to specify the python version to use.
+You will need to specify a python version that is compatible with the **labscript-suite**.
+The currently compatible versions are |PyPI pyversions|.
+It is recommended to select a newer version of python for a new install,
+though some device drivers may require an older version of python to operate correctly.
+
 .. code-block:: console
 
-    (base) C:\> conda create -n py38 python=3.8
-    (base) C:\> conda activate py38
-    (py38) C:\>
+    (base) C:\> conda create -n labscript python=3.12
+    (base) C:\> conda activate labscript
+    (labscript) C:\>
 
-Once activated, the name of the virtual environment (in this case, `py38` ) will prefix the command line.
+Once activated, the name of the virtual environment (in this case, `labscript` ) will prefix the command line.
 
 .. _Conda Instructions:
 
@@ -41,19 +48,19 @@ Detailed Instructions
 *********************
 
 1. Create a virtual (conda) environment.
-   Here we name it `py38` and ask conda to use Python 3.8 within the virtual environment (name and Python version are variable but these are conventional choices):
+   Here we name it `labscript` and ask conda to use Python 3.8 within the virtual environment (name and Python version are variable but these are conventional choices):
 
   .. code-block:: console
 
-    (base) C:\> conda create -n py38 python=3.8
+    (base) C:\> conda create -n labscript python=3.12
 
 
 2. Activate the virtual (conda) environment:
 
   .. code-block:: console
 
-    (base) C:\> conda activate py38
-    (py38) C:\>
+    (base) C:\> conda activate labscript
+    (labscript) C:\>
 
 
 Regular Python
@@ -122,3 +129,6 @@ Once you have a virtual environment up and running, choose from one of the follo
 2. :doc:`regular-anaconda`;
 3. :doc:`developer-pypi`; or
 4. :doc:`developer-anaconda`.
+
+.. |PyPI pyversions| image:: https://img.shields.io/pypi/pyversions/labscript-suite.svg
+  :target: https://pypi.python.org/pypi/labscript-suite/

--- a/docs/source/installation/setting-up-an-environment.rst
+++ b/docs/source/installation/setting-up-an-environment.rst
@@ -48,11 +48,11 @@ Detailed Instructions
 *********************
 
 1. Create a virtual (conda) environment.
-   Here we name it `labscript` and ask conda to use Python 3.8 within the virtual environment (name and Python version are variable but these are conventional choices):
+   Here we name it `labscript` and ask conda to use Python 3.11 within the virtual environment (name and Python version are variable but these are conventional choices):
 
   .. code-block:: console
 
-    (base) C:\> conda create -n labscript python=3.12
+    (base) C:\> conda create -n labscript python=3.11
 
 
 2. Activate the virtual (conda) environment:


### PR DESCRIPTION
Fixes #87 

Hopefully new users will stop defaulting to python=3.8 as a result.