### PR TITLE
Explicitly define canonical URL from RTD

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -190,8 +190,10 @@ html_static_path = ['_static']
 # Customize the html_theme
 html_theme_options = {'navigation_depth': 3}
 
-# Use m2r only for mdinclude and recommonmark for everything else
-# https://github.com/readthedocs/recommonmark/issues/191#issuecomment-622369992
+# Define the canonical URL for our custom domain on RTD
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+
 def setup(app):
 
     app.add_css_file('custom.css')


### PR DESCRIPTION
RTD is making some [changes to their build](https://about.readthedocs.com/blog/2024/07/addons-by-default/) and we need to make a small modification to stay ahead of it.