### PR TITLE
Update developer instructions to account for change pyqt

### DIFF
--- a/docs/source/installation/developer-anaconda.rst
+++ b/docs/source/installation/developer-anaconda.rst
@@ -37,7 +37,7 @@ Quick start
     (base) > git clone https://github.com/wkheisenberg/labscript-utils
     (base) > conda activate labscript
     (labscript) > conda config --env --append channels labscript-suite
-    (labscript) > conda install setuptools-conda pyqt pip desktop-app
+    (labscript) > conda install setuptools-conda pyqt=5.15.10 pip desktop-app
     (labscript) > setuptools-conda install-requirements ^ 
              labscript runmanager blacs lyse runviewer labscript-devices labscript-utils
     (labscript) > pip install --no-build-isolation --no-deps ^


### PR DESCRIPTION
conda install pyqt now defaults to pyqt6, so added the latest pyqt5 version 5.15.10. 
Otherwise qt.py from qtutils raised the error "No Qt Enviroment was detected!" because neither PySide6 nor PyQt5 was found.

For me downgrading pyqt worked.